### PR TITLE
Hide symbols for static build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ int main(void) {
 
 ### Requirements
 
-- [Meson](https://mesonbuild.com/) for building
+- [Meson](https://mesonbuild.com/) (0.54.0 or later) for building
 
 ### Build Whole Project
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ int main(void) {
 
 ### Requirements
 
-- [Meson](https://mesonbuild.com/) (0.54.0 or later) for building
+- [Meson](https://mesonbuild.com/) (0.58.0 or later) for building
 
 ### Build Whole Project
 

--- a/include/env_utils.h
+++ b/include/env_utils.h
@@ -7,13 +7,18 @@
 extern "C" {
 #endif
 
+// Export APIs when shared build
 #ifndef _ENVU_EXTERN
+#ifdef _ENVU_STATIC
+#define _ENVU_EXTERN extern
+#else  // _ENVU_STATIC
 #ifdef _WIN32
 #define _ENVU_EXTERN __declspec(dllexport) extern
-#else
+#else  // _WIN32
 #define _ENVU_EXTERN __attribute__((visibility("default"))) extern
-#endif
-#endif
+#endif  // _WIN32
+#endif  // _ENVU_STATIC
+#endif  // _ENVU_EXTERN
 
 #define _ENVU_ENUM(s) typedef unsigned int s; enum
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('c-env-utils', ['c'],
-    meson_version: '>=0.58.0',
+    meson_version: '>=0.54.0',
     default_options: [
         'buildtype=debug',              # build debug by default
         'default_library=shared',       # build shared libraries by default
@@ -92,15 +92,37 @@ elif envu_OS == 'haiku'
 endif
 
 # main binary
-env_utils = library('env_utils',
-    envu_sources,
-    dependencies: envu_lib_deps,
-    c_args: envu_c_args + envu_c_only_args,
-    cpp_args: envu_c_args,
-    link_args: envu_link_args,
-    install: true,
-    include_directories: include_directories('./include'),
-    gnu_symbol_visibility: 'hidden')
+if meson.version().version_compare('>=1.3.0')
+    env_utils = library('env_utils',
+        envu_sources,
+        dependencies: envu_lib_deps,
+        c_args: envu_c_args + envu_c_only_args,
+        c_static_args: ['-D_ENVU_STATIC'],
+        cpp_args: envu_c_args,
+        cpp_static_args: ['-D_ENVU_STATIC'],
+        link_args: envu_link_args,
+        install: true,
+        include_directories: include_directories('./include'),
+        gnu_symbol_visibility: 'hidden')
+else
+    # TODO: Remove this else block to support only meson 1.3.0 or later.
+    if get_option('default_library') == 'both'
+        error('c-env-utils requres meson 1.3.0 or later to build both shared and static libraries at the same time')
+    elif get_option('default_library') == 'static'
+        envu_c_args += ['-D_ENVU_STATIC']
+    endif
+    env_utils = library('env_utils',
+        envu_sources,
+        dependencies: envu_lib_deps,
+        c_args: envu_c_args + envu_c_only_args,
+        cpp_args: envu_c_args,
+        link_args: envu_link_args,
+        install: true,
+        include_directories: include_directories('./include'),
+        gnu_symbol_visibility: 'hidden')
+endif
+
+
 install_headers('include/env_utils.h')
 if envu_OS == 'windows'
     install_headers('include/env_utils_windows.h')

--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,7 @@ if meson.version().version_compare('>=1.3.0')
 else
     # TODO: Remove this else block to support only meson 1.3.0 or later.
     if get_option('default_library') == 'both'
-        error('c-env-utils requres meson 1.3.0 or later to build both shared and static libraries at the same time')
+        error('c-env-utils requires meson 1.3.0 or later to build both shared and static libraries at the same time')
     elif get_option('default_library') == 'static'
         envu_c_args += ['-D_ENVU_STATIC']
     endif

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('c-env-utils', ['c'],
-    meson_version: '>=0.54.0',
+    meson_version: '>=0.58.0',
     default_options: [
         'buildtype=debug',              # build debug by default
         'default_library=shared',       # build shared libraries by default


### PR DESCRIPTION
Symbols are hidden in static builds to make the compiler possible to remove unused functions.