### PR TITLE
Disable best-fit mapping on Windows

### DIFF
--- a/docs/Doxygen.md
+++ b/docs/Doxygen.md
@@ -6,6 +6,6 @@ You can build the HTML files by the following steps.
 
 - Install [Doxygen 1.9.6](https://github.com/doxygen/doxygen/releases/tag/Release_1_9_6).
 - Clone [Doxygen Awesome 2.3.1](https://github.com/jothepro/doxygen-awesome-css/tree/v2.3.1) into `./docs`.
-- Run `doxygen ./Doxyfile` on the root directory of reversi-core.
+- Run `doxygen ./Doxyfile` on the root directory of c-env-utils.
 
 Note that you should use the specified versions of tools. Or the HTML files might be broken.  

--- a/include/env_utils.h
+++ b/include/env_utils.h
@@ -23,8 +23,8 @@ extern "C" {
 #define _ENVU_ENUM(s) typedef unsigned int s; enum
 
 // Version info
-#define ENVU_VERSION "0.3.0"
-#define ENVU_VERSION_INT 300
+#define ENVU_VERSION "0.3.1"
+#define ENVU_VERSION_INT 301
 
 /**
  * Gets the version of c-env-utils.

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project('c-env-utils', ['c'],
         'cpp_eh=sc',                    # shut the compiler up in some cases
         'cpp_winlibs=',                 # likewise as with c_winlibs
     ],
-    version: '0.3.0')
+    version: '0.3.1')
 
 envu_link_args = []
 envu_c_args = []

--- a/src/env_utils_cli.c
+++ b/src/env_utils_cli.c
@@ -30,7 +30,16 @@ void PrintUTF8(const char* fmt, ...) {
 #define PRINTF(fmt, ...) printf(fmt, __VA_ARGS__)
 #endif  // _WIN32
 
+#ifdef _WIN32
+#include <locale.h>
+#endif
+
 int main(void) {
+#ifdef _WIN32
+    // Need this line to show unicode characters on Windows
+    setlocale(LC_CTYPE, "");
+#endif
+
     PRINTF("c-env-utils v%s\n", envuGetVersion());
     PRINTF("%s", "\n");
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -94,12 +94,14 @@ char *envuUTF16toUTF8(const wchar_t* wstr) {
 
     char *str;
     int wstr_len = SIZET_TO_INT(wcslen(wstr));
-    int str_len = WideCharToMultiByte(ENVU_CP_UTF8, 0, wstr, wstr_len + 1, NULL, 0, NULL, NULL);
+    int str_len = WideCharToMultiByte(ENVU_CP_UTF8, WC_NO_BEST_FIT_CHARS,
+                                      wstr, wstr_len + 1, NULL, 0, NULL, NULL);
     if (str_len == 0)
         return envuAllocEmptyStr();
 
     str = envuAllocStr(str_len);
-    int res = WideCharToMultiByte(ENVU_CP_UTF8, 0, wstr, wstr_len + 1, str, str_len, NULL, NULL);
+    int res = WideCharToMultiByte(ENVU_CP_UTF8, WC_NO_BEST_FIT_CHARS,
+                                  wstr, wstr_len + 1, str, str_len, NULL, NULL);
     if (res != str_len)
         *str = '\0';
     return str;


### PR DESCRIPTION
`WideCharToMultiByte` should be called with `WC_NO_BEST_FIT_CHARS` to fix potential issues on Windows build.

https://learn.microsoft.com/en-us/windows/win32/intl/security-considerations--international-features