### PR TITLE
Support SerenityOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ c-env-utils supports most of the desktop operating systems.
 - BSD
 - Haiku
 - Solaris
+- SerenityOS
 - Other unix variants (maybe)
 
 ## Example

--- a/docs/ReturnValues.md
+++ b/docs/ReturnValues.md
@@ -15,6 +15,7 @@ Examples of return values for envuGetOS(), envuGetOSVersion(), and envuGetOSProd
 | OpenBSD | 7.4 | OpenBSD 7.4 |
 | SunOS | 5.11 | OpenIndiana Hipster 2024.04 |
 | Haiku | 1 | Haiku R1/beta4 |
+| SerenityOS | 1.0 | SerenityOS |
 
 ## envuGetFullPath
 

--- a/src/unix.c
+++ b/src/unix.c
@@ -655,6 +655,8 @@ char *envuGetOSProductName(void) {
     return getOSProductNameLinux();
 #elif defined(__sun)
     return getOSProductNameSolaris();
+#elif defined(__serenity__)
+    return envuGetOS();  // Note: SerenityOS has no versions.
 #else
     return getOSProductNameOthers();
 #endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -52,6 +52,8 @@ else
         # get os name from /etc/release
         r = run_command('head', '-1', '/etc/release', check: true)
         true_os_product_name = r.stdout().split('(')[0].strip()
+    elif envu_OS == 'serenityos'
+        true_os_product_name = true_os
     else
         true_os_product_name = true_os + ' ' + true_os_version
     endif
@@ -88,17 +90,22 @@ if envu_OS != 'windows'
 endif
 
 test_cpp_args = []
+test_link_args = []
 if envu_OS == 'windows'
     if envu_compiler == 'msvc'
         test_cpp_args += ['/source-charset:utf-8']
     elif envu_compiler == 'gcc'
         test_cpp_args += ['-finput-charset=UTF-8']
     endif
+elif envu_OS == 'serenityos' and envu_compiler == 'gcc'
+    # SerenityOS seems to require this flag for GCC
+    test_link_args += ['-lgcc_s']
 endif
 
 test_exe = executable('env_utils_test',
     'main.cpp',
     cpp_args: test_cpp_args,
+    link_args: test_link_args,
     dependencies : [env_utils_dep, gtest_dep, gmock_dep],
     install : false)
 


### PR DESCRIPTION
[SerenityOS](https://github.com/SerenityOS/serenity) is a modern Unix-like system with retro UI. A test case (`envuSetEnvEmpy`) fails but I think it's SerenityOS's issue.

```c++
TEST(UtilTest, envuSetEnvEmpty) {
    // This should do nothing.
    int ret = envuSetEnv("", "test");
    EXPECT_EQ(-1, ret);
    char* env = envuGetEnv("");
    ASSERT_EQ(NULL, env);
}
```

<details><summary>Commands I executed</summary>

```bash
# on Ubuntu 24.04
sudo apt update
# Required for OS
sudo apt install git build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-gui qemu-system-x86 qemu-utils ccache rsync unzip texinfo libssl-dev
# Required for Ports
sudo apt install imagemagick zlib1g-dev m4 gettext

# Clone repo
git clone https://github.com/SerenityOS/serenity.git
cd serenity

# Build OS and toolchain
./Meta/serenity.sh build
./Toolchain/BuildPython.sh

# Include ports
# Note: You can't do "./Ports/*/package.sh"
# Note: You should build gcc before building python3
for dir in bash curl git pkgconf gcc ninja python3; do
    (cd "Ports/$dir" && ./package.sh && cd ../..)
done

# Build and run Serenity OS
Meta/serenity.sh run

# -------------------------
# on Serenity OS
cd ~/
git clone --depth 1 https://github.com/mesonbuild/meson.git
git clone https://github.com/matyalatte/c-env-utils.git
cd c-env-utils

# Build and test
python3 ~/meson/meson.py setup build
python3 ~/meson/meson.py compile -C build
python3 ~/meson/meson.py test -C build
./build/env_utils_cli
```
</details>